### PR TITLE
Add custom toLinkedMap collector

### DIFF
--- a/com.langtoun.oastypes/src/main/java/com/langtoun/oastypes/impl/OASObjectTypeImpl.java
+++ b/com.langtoun.oastypes/src/main/java/com/langtoun/oastypes/impl/OASObjectTypeImpl.java
@@ -2,8 +2,9 @@ package com.langtoun.oastypes.impl;
 
 import static com.langtoun.oastypes.util.StringExtensions.doubleQuote;
 import static org.apache.commons.text.StringEscapeUtils.escapeJson;
+import static com.langtoun.oastypes.util.CollectorUtil.toLinkedMap;
 
-import java.util.LinkedHashMap;
+import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -116,16 +117,15 @@ public class OASObjectTypeImpl extends OASTypeImpl implements OASObjectType {
 
     public Builder properties() {
       final Map<String, Schema> properties = schema.getProperties();
-      oasObjectType.properties = new LinkedHashMap<>();
-
-      for (Entry<String, Schema> property : properties.entrySet()) {
-        final String key = property.getKey();
-        final Schema value = property.getValue();
-        oasObjectType.properties.put(
-          key,
-          OASTypeFactory.createOASType(value, Overlay.of(properties).getReference(key))
-        );
-      }
+      oasObjectType.properties =
+        properties.entrySet().stream()
+          .map(e ->
+            new AbstractMap.SimpleEntry<>(
+              e.getKey(),
+              OASTypeFactory.createOASType(e.getValue(), Overlay.of(properties).getReference(e.getKey()))
+            )
+          )
+          .collect(toLinkedMap(Entry::getKey, Entry::getValue));
       return this;
     }
 

--- a/com.langtoun.oastypes/src/main/java/com/langtoun/oastypes/util/CollectorUtil.java
+++ b/com.langtoun.oastypes/src/main/java/com/langtoun/oastypes/util/CollectorUtil.java
@@ -1,0 +1,35 @@
+package com.langtoun.oastypes.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/**
+ * Additional collectors for use with Stream::collect.
+ */
+public final class CollectorUtil {
+
+  /**
+   * Create a two parameter collector that uses a {@link LinkedHashMap}.
+   *
+   * @param keyMapper  The function that provides the key value.
+   * @param valueMapper  The function that provides the mapped value.
+   * @return
+   */
+  public static <T, K, U> Collector<T, ?, Map<K, U>> toLinkedMap(
+    Function<? super T, ? extends K> keyMapper,
+    Function<? super T, ? extends U> valueMapper
+  ) {
+    return Collectors.toMap(
+      keyMapper,
+      valueMapper,
+      (u, v) -> {
+        throw new IllegalStateException(String.format("Duplicate key %s", u));
+      },
+      LinkedHashMap::new
+    );
+  }
+
+}


### PR DESCRIPTION
New CollectorUtil class was created with a toLinkedMap static method. This method can be used when processing map entry sets using streams. It ensures that, if a map was created with a LinkedHashMap signifying that the key order is important, it isn't re-ordered during collection. This was added primarily for use with property maps.